### PR TITLE
Allow user to pass ref and only return bounds

### DIFF
--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -39,10 +39,13 @@ interface ResizeObserver {
   disconnect(): void
 }
 
-type Measure = [React.MutableRefObject<HTMLDivElement | null>, RectReadOnly]
+type DivRef = React.MutableRefObject<HTMLDivElement | null>
+type Measure = [DivRef, RectReadOnly]
 
-export default function useMeasure(): Measure {
-  const ref = useRef<HTMLDivElement>(null)
+function useMeasure(): Measure
+function useMeasure(ref: DivRef): RectReadOnly
+function useMeasure(maybeRef?: DivRef): Measure | RectReadOnly {
+  const ref = maybeRef || useRef<HTMLDivElement>(null)
   const [bounds, set] = useState<RectReadOnly>({
     left: 0,
     top: 0,
@@ -74,5 +77,8 @@ export default function useMeasure(): Measure {
     if (ref.current) ro.observe(ref.current)
     return () => ro.disconnect()
   }, [])
-  return [ref, bounds]
+  if (!maybeRef) return [ref, bounds]
+  return bounds
 }
+
+export default useMeasure


### PR DESCRIPTION
As discussed on Twitter: https://twitter.com/0xca0a/status/1190280933712248832

Note that the usage section of the `README.md` should be updated as well:

```diff
const ref = useRef()
- const [, bounds] = useMeasure(ref)
+ const bounds = useMeasure(ref)
return <div ref={ref} />
```

I think this section is currently incorrect since you can't pass a ref to useMeasure (before this change).

Also `DivRef` is a bit of a strange type but not sure how to solve it more cleanly 🤷‍♂️